### PR TITLE
use file.clone()

### DIFF
--- a/index.js
+++ b/index.js
@@ -50,6 +50,7 @@ function gulprsvg() {
             done();
         } else {
             var svg = new Rsvg(file.contents);
+            file = file.clone();
             file.path = gutil.replaceExtension(file.path, '.' + options.format);
             file.contents = new Buffer(svg.render({
                 format: options.format,


### PR DESCRIPTION
I added a `file.clone()`  to enable multiple stream to work on the same file.
this would let me do something like this
What do you think?

``` js
  var svg = gulp
    .src('images/svg/*.svg');

  var png32 = svg
    .pipe(rsvg({ width: 32, height: 32 }))
    .pipe(gulp.dest('images/png-32'));

  var png64 = svg
     .pipe(rsvg({ width: 64, height: 64 }))
     .pipe(gulp.dest('images/png-64'));

  return es.merge(png32, png64);
```
