### PR TITLE
add Rsvg option

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,3 +58,9 @@ Type: `Integer`
 Default value: 1
 
 Scale the generated file by this factor. Useful for retina assets.
+
+### Rsvg
+Type: `Function`
+Default value: `require('rsvg').Rsvg`
+
+Pass a svg rendering library. `Rsvg` by npm package `rsvg` used by default.

--- a/index.js
+++ b/index.js
@@ -2,8 +2,7 @@
 
 'use strict';
 
-var Rsvg          = require('rsvg').Rsvg,
-    gutil         = require('gulp-util'),
+var gutil         = require('gulp-util'),
     transform     = require('stream').Transform,
 
     PLUGIN_NAME   = 'gulp-rsvg';
@@ -12,6 +11,8 @@ function gulprsvg(options) {
     options = options || {};
     options.format = options.format || 'png';
     options.scale = options.scale || 1;
+
+    var Rsvg = options.Rsvg || require('rsvg').Rsvg;
 
     function renderSvg(svg) {
         return new Buffer(svg.render({


### PR DESCRIPTION
It would be good if we have a possibility to use different svg rendering libraries (or forks of rsvg),
like [librsvg](https://www.npmjs.com/package/librsvg) for example, which fixes some issues of original rsvg package.
