### PR TITLE
move to librsvg instead of rsvg

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > Convert SVG to PNG or PDF.
 
-*If you have any difficulties with the output of this plugin, please use the [RSVG tracker](https://github.com/walling/node-rsvg/issues).*
+*If you have any difficulties with the output of this plugin, please use the [RSVG tracker](https://github.com/anru/node-rsvg/issues).*
 
 Install via [npm](https://npmjs.org/package/gulp-rsvg):
 
@@ -10,7 +10,7 @@ Install via [npm](https://npmjs.org/package/gulp-rsvg):
 npm install gulp-rsvg --save-dev
 ```
 
-Note that this plugin wraps [node-rsvg](https://github.com/walling/node-rsvg) and so requires LibRSVG to be available on the command line. Please see the README for *node-rsvg* for a guide on how to set that up for your platform.
+Note that this plugin wraps [node-rsvg](https://github.com/anru/node-rsvg) and so requires LibRSVG to be available on the command line. Please see the README for *node-rsvg* for a guide on how to set that up for your platform.
 
 ## Example
 
@@ -61,6 +61,6 @@ Scale the generated file by this factor. Useful for retina assets.
 
 ### Rsvg
 Type: `Function`
-Default value: `require('rsvg').Rsvg`
+Default value: `require('librsvg').Rsvg`
 
-Pass a svg rendering library. `Rsvg` by npm package `rsvg` used by default.
+Pass a svg rendering library. `Rsvg` by npm package `librsvg` used by default.

--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ function gulprsvg(options) {
     options.format = options.format || 'png';
     options.scale = options.scale || 1;
 
-    var Rsvg = options.Rsvg || require('rsvg').Rsvg;
+    var Rsvg = options.Rsvg || require('librsvg').Rsvg;
 
     function renderSvg(svg) {
         return new Buffer(svg.render({
@@ -29,9 +29,10 @@ function gulprsvg(options) {
         if (file.isNull()) {
             return done(null, file);
         }
+        var svg;
 
         if (file.isStream()) {
-            var svg = new Rsvg();
+            svg = new Rsvg();
             file.contents.pipe(svg);
 
             svg.on('finish', function() {
@@ -39,7 +40,7 @@ function gulprsvg(options) {
                 done(null, file);
             });
         } else {
-            var svg = new Rsvg(file.contents);
+            svg = new Rsvg(file.contents);
             file.path = gutil.replaceExtension(file.path, '.' + options.format);
             file.contents = renderSvg(svg);
             done(null, file);

--- a/package.json
+++ b/package.json
@@ -24,19 +24,19 @@
     "gulp-util": "~2.2.0"
   },
   "peerDependencies": {
-    "rsvg": "*"
+    "librsvg": "*"
   },
   "devDependencies": {
-    "rsvg": "~0.2.3",
     "chai": "~1.8.1",
     "clear": "0.0.1",
-    "gulp": "~3.2.3",
-    "gulp-mocha": "~0.2.0",
+    "event-stream": "~3.1.0",
+    "gulp": "^3.8.10",
     "gulp-jshint": "~1.3.4",
+    "gulp-mocha": "~0.2.0",
     "gulp-util": "~2.2.6",
     "jshint-stylish": "~0.1.5",
-    "mocha": "~1.16.2",
-    "event-stream": "~3.1.0"
+    "librsvg": "~0.5.0",
+    "mocha": "~1.16.2"
   },
   "main": "index.js"
 }


### PR DESCRIPTION
I offer to switch dependency rsvg to my fork of node-rsvg — [librsvg](https://github.com/anru/node-rsvg). Original node-rsvg doesn't accept my pull request walling/node-rsvg#4 more than six months. Also I fix problem when node-rsvg renders zero-sized buffer  of normal svg image in rare but real cases.
