### PR TITLE
Remove dependency on gulp-util

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,8 +1,8 @@
 'use strict';
 
-var gutil     = require('gulp-util'),
-    assign    = require('object-assign'),
-    transform = require('stream').Transform;
+var replaceExtension = require('replace-ext'),
+    assign           = require('object-assign'),
+    transform        = require('stream').Transform;
 
 module.exports = function gulprsvg (options) {
     options = assign({
@@ -40,7 +40,7 @@ module.exports = function gulprsvg (options) {
             });
         } else {
             svg = new Rsvg(file.contents);
-            file.path = gutil.replaceExtension(file.path, '.' + options.format);
+            file.path = replaceExtension(file.path, '.' + options.format);
             file.contents = renderSvg(svg);
             cb(null, file);
         }

--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ module.exports = function gulprsvg (options) {
     var Rsvg = options.Rsvg;
 
     function renderSvg (svg) {
-        return new Buffer(svg.render({
+        return Buffer.from(svg.render({
             format: options.format,
             width: options.width || svg.width * options.scale,
             height: options.height || svg.height * options.scale

--- a/package.json
+++ b/package.json
@@ -22,13 +22,14 @@
     "LICENSE-MIT"
   ],
   "dependencies": {
-    "gulp-util": "~3.0.3",
     "librsvg": "~0.7.0",
-    "object-assign": "^4.0.1"
+    "object-assign": "^4.0.1",
+    "replace-ext": "^2.0.0"
   },
   "devDependencies": {
     "tap-spec": "^4.1.0",
-    "tape": "^4.2.0"
+    "tape": "^4.2.0",
+    "vinyl": "^2.2.0"
   },
   "main": "index.js"
 }

--- a/test.js
+++ b/test.js
@@ -27,7 +27,7 @@ test('should convert svg to png', function (t) {
         t.ok(~file.path.indexOf('png'), 'should be a png');
     });
 
-    stream.write(fixture(new Buffer(raw)));
+    stream.write(fixture(Buffer.from(raw)));
 });
 
 test('should convert svg to pdf', function (t) {
@@ -40,7 +40,7 @@ test('should convert svg to pdf', function (t) {
         t.ok(~file.path.indexOf('pdf'), 'should be a pdf');
     });
 
-    stream.write(fixture(new Buffer(raw)));
+    stream.write(fixture(Buffer.from(raw)));
 });
 
 test('should work the same with streams', function (t) {

--- a/test.js
+++ b/test.js
@@ -4,12 +4,12 @@ var convert = require('./index'),
     test    = require('tape'),
     Stream  = require('stream'),
     fs      = require('fs'),
-    gutil   = require('gulp-util');
+    Vinyl   = require('vinyl');
 
 var raw = fs.readFileSync('./fixture.svg', 'utf-8');
 
 function fixture (contents) {
-    return new gutil.File({
+    return new Vinyl({
         contents: contents,
         cwd: __dirname,
         base: __dirname,


### PR DESCRIPTION
`gulp-util` was [deprecated](https://medium.com/gulpjs/gulp-util-ca3b1f9f9ac5) a while back, and while this isn’t the end of the world, it in turn unfortunately depends on a version of lodash with a [critical vulnerability](https://github.com/advisories/GHSA-jf85-cpcp-j695).
This was causing security alerts on a project I’m working on, and in turn was causing our CTO to jump up and down in an amusingly animated manner :)

Either way, I’ve switched out `replaceExtension` calls to use the `replace-ext` module, and `gutil.File` to use standard Vinyl objects. I also switched instances of `new Buffer()` to `Buffer.from(string)` to get rid of some deprecation warnings.
I’ve not bumped any other deps—I’ll leave that to your discretion. Tests seem to pass OK, but apologies in advance if I’ve missed anything else.

Otherwise, thanks for making this plugin—switching to it shaved a couple minutes off our project’s build time, which makes me all kinds of happy!